### PR TITLE
Add missing certificate to access AWS API

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -17,7 +17,11 @@
 name "cacerts"
 
 # Date of the file is in a comment at the start, or in the changelog
-default_version "2014.09.03"
+default_version "2015.02.25"
+
+version "2015.02.25" do
+  source md5: "19e7f27540ee694308729fd677163649"
+end
 
 version "2014.09.03" do
   source md5: "d7f7dd7e3ede3e323fc0e09381f16caf"

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -51,6 +51,29 @@ build do
   mkdir "#{install_dir}/embedded/ssl/certs"
   copy "#{project_dir}/cacert.pem", "#{install_dir}/embedded/ssl/certs/cacert.pem"
 
+  block {
+    File.open("#{install_dir}/embedded/ssl/certs/cacert.pem", "a") do |f|
+      f.write "
+Verisign Class 3 Public Primary Certification Authority 2
+=========================================================
+-----BEGIN CERTIFICATE-----
+MIICPDCCAaUCEDyRMcsf9tAbDpq40ES/Er4wDQYJKoZIhvcNAQEFBQAwXzELMAkG
+A1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMTcwNQYDVQQLEy5DbGFz
+cyAzIFB1YmxpYyBQcmltYXJ5IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTk2
+MDEyOTAwMDAwMFoXDTI4MDgwMjIzNTk1OVowXzELMAkGA1UEBhMCVVMxFzAVBgNV
+BAoTDlZlcmlTaWduLCBJbmMuMTcwNQYDVQQLEy5DbGFzcyAzIFB1YmxpYyBQcmlt
+YXJ5IENlcnRpZmljYXRpb24gQXV0aG9yaXR5MIGfMA0GCSqGSIb3DQEBAQUAA4GN
+ADCBiQKBgQDJXFme8huKARS0EN8EQNvjV69qRUCPhAwL0TPZ2RHP7gJYHyX3KqhE
+BarsAx94f56TuZoAqiN91qyFomNFx3InzPRMxnVx0jnvT0Lwdd8KkMaOIG+YD/is
+I19wKTakyYbnsZogy1Olhec9vn2a/iRFM9x2Fe0PonFkTGUugWhFpwIDAQABMA0G
+CSqGSIb3DQEBBQUAA4GBABByUqkFFBkyCEHwxWsKzH4PIRnN5GfcX6kb5sroc50i
+2JhucwNhkcV8sEVAbkSdjbCxlnRhLQ2pRdKkkirWmnWXbj9T/UWZYB2oK0z5XqcJ
+2HUw19JlYD1n1khVdWk/kfVIC0dpImmClr7JyDiGSnoscxlIaU5rfGW/D/xwzoiQ
+-----END CERTIFICATE-----
+"
+    end
+  }
+
   # Windows does not support symlinks
   unless windows?
     link "#{install_dir}/embedded/ssl/certs/cacert.pem", "#{install_dir}/embedded/ssl/cert.pem"


### PR DESCRIPTION
omnibus-software で同梱する CA 証明書のバージョンが最新の 2015.02.25 だと、AWS API で使われている証明書の発行元 CA 証明書が含まれていません。そのため、Certificate Verify Failed が発生して AWS API にアクセスできず、 Itamae から EC2 tags を取得することができません。とは言え、証明書のバージョンを古いバージョンで固定するのもセキュリティ上問題があるため、必要な証明書のみ追加するようにしてみました。

Ref: https://github.com/chef/omnibus-software/issues/348

確認お願いします。
